### PR TITLE
Bpatch nvidia fix

### DIFF
--- a/Source/PeleLMeX_BPatch.H
+++ b/Source/PeleLMeX_BPatch.H
@@ -220,6 +220,7 @@ public:
 
   // Accessors
   BpatchDataContainer getHostData() { return m_bpdata_h; }
+  BpatchDataContainer* getHostDataPtr() { return &m_bpdata_h; }
   BpatchDataContainer* getDeviceData() { return m_bpdata_d; }
 
   std::string m_patchname;

--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -557,6 +557,9 @@ PeleLM::addRhoYFluxesPatch(
 #if (AMREX_SPACEDIM == 1)
   area[0] = 1.0;
 #elif (AMREX_SPACEDIM == 2)
+  if (geom[0].IsRZ() && m_bPatches.size() > 0) {
+    Abort("Bpatches not supported in RZ coordinates");
+  }
   area[0] = dx[1];
   area[1] = dx[0];
 #else


### PR DESCRIPTION
Don't access device pointers from host. Also abort in RZ mode because the areas would be wrong (compare to regular addRhoYFluxes function that corrects for this). 